### PR TITLE
Issue #3: Add missing hook_config_info implementation.

### DIFF
--- a/bigmenu.info
+++ b/bigmenu.info
@@ -2,3 +2,5 @@ name = Big Menu
 description = Scalable replacement for core menu management screen for large hierarchical menus.
 backdrop = 1.x
 type = module
+
+configure = admin/config/user-interface/bigmenu

--- a/bigmenu.module
+++ b/bigmenu.module
@@ -100,3 +100,14 @@ function bigmenu_menu_alter(&$items) {
   $items['admin/structure/menu/manage/%menu']['file'] = 'bigmenu.admin.inc';
   $items['admin/structure/menu/manage/%menu']['file path'] = backdrop_get_path('module', 'bigmenu');
 }
+
+/**
+ * Implements hook_config_info().
+ */
+function bigmenu_config_info() {
+  $prefixes['bigmenu.settings'] = array(
+    'label' => t('Big Menu settings'),
+    'group' => t('Configuration'),
+  );
+  return $prefixes;
+}


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bigmenu/issues/3.

Also add the missing "configure = …" entry in the .info file.