### PR TITLE
Issue #6: Eliminate “undefined $mlid” warning in dblog.

### DIFF
--- a/bigmenu.admin.inc
+++ b/bigmenu.admin.inc
@@ -294,17 +294,18 @@ function _bigmenu_overview_tree_form($tree, $depth = 0) {
         _bigmenu_overview_tree_form($data['below'], $depth - 1);
       }
       else {
-        // 'below' contains both immediate children and something else.
-        $strings = array(
-          '!show_children' => t('Show children'),
-          '%count' => count($data['below']),
-          '!tooltip' => t('Click to expand and show child items'),
-        );
-        $text = strtr('<span class="bigmenu-toggle">+</span> <span class="count" title="!tooltip"><span class="hide-show">!show_children</span> (%count)</span>', $strings);
-        $indicator = l($text, "admin/structure/menu/manage/{$item['menu_name']}/bigmenu-customize/subform/{$item['mlid']}", array('html' => TRUE, 'attributes' => array('class' => array('bigmenu-childindictor'))));
-        $form[$mlid]['title']['#markup'] .= '<br/>' . $indicator;
-        $form[$mlid]['#attributes']['class'][] = 'bigmenu-collapsed';
-
+        if (isset($mlid)) {
+          // 'below' contains both immediate children and something else.
+          $strings = array(
+            '!show_children' => t('Show children'),
+            '%count' => count($data['below']),
+            '!tooltip' => t('Click to expand and show child items'),
+          );
+          $text = strtr('<span class="bigmenu-toggle">+</span> <span class="count" title="!tooltip"><span class="hide-show">!show_children</span> (%count)</span>', $strings);
+          $indicator = l($text, "admin/structure/menu/manage/{$item['menu_name']}/bigmenu-customize/subform/{$item['mlid']}", array('html' => TRUE, 'attributes' => array('class' => array('bigmenu-childindictor'))));
+          $form[$mlid]['title']['#markup'] .= '<br/>' . $indicator;
+          $form[$mlid]['#attributes']['class'][] = 'bigmenu-collapsed';
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/bigmenu/issues/6.